### PR TITLE
Update to avoid using character time vector

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidycmprsk
 Title: Competing Risks Estimation
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: c(
     person(c("Daniel", "D."), "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidycmprsk (development version)
 
+* The `cmprsk::timepoints()` function returns cumulative incidence estimates with the timepoints as character column names. To avoid potential rounding issues converting numeric times to character and back to numeric, we now pass the replace the character times with numeric.
+
 * Update the `crr()` print method for more clarity.
 
 # tidycmprsk 0.1.0

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -15,7 +15,7 @@
 #' or replace existing arguments in the `ggplot2::aes()` call.
 #' The tibble used to create the figure is the output from `tidy()`.
 #' The default call to `ggplot2::aes()` includes, at most, the following:
-#' `ggplot2::aes(x = time, y = estimate, colour = strata, fill = strata, linetype = outcome, ymin = conf.low, ymax = conf.high`
+#' `ggplot2::aes(x = time, y = estimate, colour = strata, fill = strata, linetype = outcome, ymin = conf.low, ymax = conf.high)`
 #' Not all arguments appear in every plot, however.
 #'
 #'

--- a/man/autoplot.tidycuminc.Rd
+++ b/man/autoplot.tidycuminc.Rd
@@ -43,7 +43,7 @@ The \verb{aes=} argument accepts a named list of arguments that will be added to
 or replace existing arguments in the \code{ggplot2::aes()} call.
 The tibble used to create the figure is the output from \code{tidy()}.
 The default call to \code{ggplot2::aes()} includes, at most, the following:
-\verb{ggplot2::aes(x = time, y = estimate, colour = strata, fill = strata, linetype = outcome, ymin = conf.low, ymax = conf.high}
+\code{ggplot2::aes(x = time, y = estimate, colour = strata, fill = strata, linetype = outcome, ymin = conf.low, ymax = conf.high)}
 Not all arguments appear in every plot, however.
 }
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
- The `cmprsk::timepoints()` function returns cumulative incidence estimates with the timepoints as character column names. To avoid potential rounding issues converting numeric times to character and back to numeric, we now utilize the numeric user-passed time vector eliminating the need to coerce the character time vector back to numeric.

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [x] If a new function was added, function included in `_pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [x] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# tidycmprsk (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end of the update.
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

