### PR TITLE
Update to `n.risk`

### DIFF
--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -103,6 +103,11 @@ augment.tidycrr <- function(x, times = NULL, probs = NULL, newdata = NULL, ...) 
 #' knitr::kable()
 #' ```
 #'
+#' If `tidy(time=)` is specified, then `n.event` and `n.censor` are the
+#' cumulative number of events/censored in the interval. For example, if
+#' `tidy(time = c(0, 12, 18))` is passed, `n.event` and `n.censor` at `time = 18`
+#' are the cumulative number of events/censored in the interval `(12, 18]`.
+#'
 #' @inheritSection cuminc Confidence intervals
 #'
 #' @examples

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -113,12 +113,13 @@ augment.tidycrr <- function(x, times = NULL, probs = NULL, newdata = NULL, ...) 
 #' glance(cuminc)
 NULL
 
-
 #' @rdname broom_methods_cuminc
 #' @export
 #' @family cuminc tidiers
-tidy.tidycuminc <- function(x, times = NULL,
-                            conf.int = TRUE, conf.level = x$conf.level, ...) {
+tidy.tidycuminc <- function(x,
+                            times = NULL,
+                            conf.int = TRUE,
+                            conf.level = x$conf.level, ...) {
   # check inputs ---------------------------------------------------------------
   if (!is.numeric(conf.level) || !dplyr::between(conf.level, 0, 1)) {
     stop("`conf.level=` must be between 0 and 1")
@@ -192,8 +193,6 @@ tidy.tidycuminc <- function(x, times = NULL,
     filter(.data$time %in% .env$times) %>%
     group_by(across(any_of(c("strata", "outcome")))) %>%
     mutate(
-      n.risk.survfit = .data$n.risk,
-      n.risk = .data$n.risk - .data$n.event - .data$n.censor,
       n.event = c(.data$cumulative.event[1],diff(.data$cumulative.event)),
       n.censor = c(.data$cumulative.censor[1],diff(.data$cumulative.censor))
     )  %>%
@@ -212,7 +211,8 @@ tidy.tidycuminc <- function(x, times = NULL,
     df_tidy <-
       df_tidy %>%
       select(-.data$conf.low, -.data$conf.high)
-  } else if (!identical(conf.level, 0.95)) {
+  }
+  else if (!identical(conf.level, x$conf.level)) {
     df_tidy <- add_conf.int(df_tidy, conf.level = conf.level)
   }
 

--- a/man/broom_methods_cuminc.Rd
+++ b/man/broom_methods_cuminc.Rd
@@ -44,6 +44,12 @@ The returned \code{tidy()} data frame returns the following columns:\tabular{ll}
    \code{cumulative.event} \tab Cumulative number of events at specified time \cr
    \code{cumulative.censor} \tab Cumulative number of censored observations at specified time \cr
 }
+
+
+If \code{tidy(time=)} is specified, then \code{n.event} and \code{n.censor} are the
+cumulative number of events/censored in the interval. For example, if
+\code{tidy(time = c(0, 12, 18))} is passed, \code{n.event} and \code{n.censor} at \code{time = 18}
+are the cumulative number of events/censored in the interval \verb{(12, 18]}.
 }
 
 \section{Confidence intervals}{

--- a/tests/testthat/test-cuminc-broom_methods.R
+++ b/tests/testthat/test-cuminc-broom_methods.R
@@ -147,6 +147,11 @@ test_that("broom methods", {
     )
 
   expect_equal(
+    survfit_check1_time$n.risk.x,
+    survfit_check1_time$n.risk.y
+  )
+
+  expect_equal(
     survfit_check1_time$n.event.x,
     survfit_check1_time$n.event.y
   )

--- a/tests/testthat/test-cuminc-broom_methods.R
+++ b/tests/testthat/test-cuminc-broom_methods.R
@@ -136,7 +136,7 @@ test_that("broom methods", {
   survfit_check1_time <-
     cuminc1_tidy_time %>%
     filter(outcome == "death from cancer") %>%
-    select(time, n.risk.survfit, n.event) %>%
+    select(time, n.risk, n.event) %>%
     dplyr::inner_join(
       data.frame(
         time = survfit1_cancer_times$time,
@@ -146,10 +146,6 @@ test_that("broom methods", {
       by = c("time")
     )
 
-  expect_equal(
-    survfit_check1_time$n.risk,
-    survfit_check1_time$n.risk.survfit
-  )
   expect_equal(
     survfit_check1_time$n.event.x,
     survfit_check1_time$n.event.y


### PR DESCRIPTION
**What changes are proposed in this pull request?**
- Removed `n.risk.survfit` from `tidy.tidycuminc()` output
- Fix in `tidy.tidycuminc()` where CIs are re-estimated when the `conf.level` is different than that called in `cuminc()`.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #51 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# tidycmprsk (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end of the update.
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

