### PR TITLE
Debian UTF-related R CMD Check Error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidycmprsk
 Title: Competing Risks Estimation
-Version: 0.1.1.9001
+Version: 0.1.1.9002
 Authors@R: c(
     person(c("Daniel", "D."), "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidycmprsk (development version)
 
+* Fix in the documentation for `tbl_cuminc()` that resulted in a UTF-related error on Debian system R CMD Check. (#65)
+
 * Adding `vcov()` method for `crr()` models (#63)
 
 # tidycmprsk 0.1.1

--- a/R/tbl_cuminc.R
+++ b/R/tbl_cuminc.R
@@ -53,7 +53,7 @@ tbl_cuminc.tidycuminc <- function(x,
                                   label_header = "**Time {time}**",
                                   estimate_fun = NULL,
                                   conf.level = x$conf.level,
-                                  missing = "\U2014",
+                                  missing = NULL,
                                   ...) {
   # check inputs ---------------------------------------------------------------
   rlang::check_dots_empty()
@@ -70,6 +70,7 @@ tbl_cuminc.tidycuminc <- function(x,
     stop("Error in `outcomes=` specification.", call. = FALSE)
   }
   func_inputs <- as.list(environment())
+  missing <- missing %||% "\U2014"
 
   # setting defaults -----------------------------------------------------------
   outcomes <- outcomes %||% names(x$failcode)[1]

--- a/man/tbl_cuminc.Rd
+++ b/man/tbl_cuminc.Rd
@@ -14,7 +14,7 @@
   label_header = "**Time {time}**",
   estimate_fun = NULL,
   conf.level = x$conf.level,
-  missing = "—",
+  missing = NULL,
   ...
 )
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* Fix in the documentation for `tbl_cuminc()` that resulted in a UTF-related error on Debian system R CMD Check. (#65)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #65

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# tidycmprsk (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end of the update.
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

