### PR TITLE
#74 avoiding warning with tied times

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidycmprsk
 Title: Competing Risks Estimation
-Version: 0.1.2.9000
+Version: 0.1.2.9001
 Authors@R: c(
     person(c("Daniel", "D."), "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018")),
@@ -41,4 +41,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidycmprsk (development version)
 
+* Re-wrote an `ifelse()` statement to avoid a warning when tied times are present in `cuminc()`. (#74)
+
 # tidycmprsk 0.1.2
 
 * The `"strata"` column in tidied `cuminc()` results is now a factor. (#62)

--- a/R/base_methods.R
+++ b/R/base_methods.R
@@ -1,5 +1,6 @@
 #' Estimate subdistribution functions for crr objects
 #'
+#' @param object a tidycrr object
 #' @param times Numeric vector of times to obtain risk estimates at
 #' @param probs Numeric vector of quantiles to obtain estimates at
 #' @param newdata A `base::data.frame()` or `tibble::tibble()` containing all

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -1,5 +1,6 @@
 #' Broom methods for tidycrr objects
 #'
+#' @param x a tidycrr object
 #' @param exponentiate Logical indicating whether or not to exponentiate the
 #' coefficient estimates. Defaults to `FALSE`.
 #' @param conf.level Level of the confidence interval. Default matches that in
@@ -378,10 +379,12 @@ add_n_stats <- function(df_tidy, x) {
     ) %>%
     group_by(across(any_of(c("strata", "time")))) %>%
     mutate(
-      outcome = ifelse(.data$status != 0,
-                       dplyr::recode(.data$status, !!!(as.list(names(x$failcode)) %>% stats::setNames(unlist(x$failcode)))),
-                       "censored"
-      )
+      outcome =
+        dplyr::recode(
+          .data$status,
+          `0` = "censored",
+          !!!(as.list(names(x$failcode)) %>% stats::setNames(unlist(x$failcode)))
+        )
     ) %>%
     select(-.data$status) %>%
     dplyr::ungroup() %>%

--- a/man/tidycmprsk-package.Rd
+++ b/man/tidycmprsk-package.Rd
@@ -6,7 +6,7 @@
 \alias{tidycmprsk-package}
 \title{tidycmprsk: Competing Risks Estimation}
 \description{
-Provides an intuitive interface for working with the competing risk endpoints. The package wraps the 'cmprsk' package, and exports functions for univariate cumulative incidence estimates and competing risk regression. Methods follow those introduced in Fine and Gray (1999) <doi:10.1002/sim.7501>.
+Provides an intuitive interface for working with the competing risk endpoints. The package wraps the 'cmprsk' package, and exports functions for univariate cumulative incidence estimates and competing risk regression. Methods follow those introduced in Fine and Gray (1999) \doi{10.1002/sim.7501}.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test-cuminc.R
+++ b/tests/testthat/test-cuminc.R
@@ -84,7 +84,8 @@ test_that("cuminc() works", {
 
   # no warnings with tied times
   expect_warning(
-    cuminc(Surv(drat, factor(cyl)) ~ 1, mtcars)
+    cuminc(Surv(drat, factor(cyl)) ~ 1, mtcars),
+    NA
   )
 })
 

--- a/tests/testthat/test-cuminc.R
+++ b/tests/testthat/test-cuminc.R
@@ -81,5 +81,10 @@ test_that("cuminc() works", {
       purrr::pluck("tidy", "strata") %>%
       inherits("factor")
   )
+
+  # no warnings with tied times
+  expect_warning(
+    cuminc(Surv(drat, factor(cyl)) ~ 1, mtcars)
+  )
 })
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Re-wrote an `ifelse()` statement to avoid a warning when tied times are present in `cuminc()`. (#74)

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #74 

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# tidycmprsk (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end of the update.
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

