### PR TITLE
Updated `cuminc()` and `crr()` to drop un-observed factor levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     cmprsk (>= 2.2.10),
     dplyr (>= 1.0.7),
     ggplot2 (>= 3.3.5),
-    gtsummary (>= 1.5.2),
+    gtsummary (>= 1.6.1),
     hardhat (>= 0.2.0),
     purrr (>= 0.3.4),
     rlang (>= 1.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidycmprsk
 Title: Competing Risks Estimation
-Version: 0.1.2.9001
+Version: 0.1.2.9003
 Authors@R: c(
     person(c("Daniel", "D."), "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidycmprsk (development version)
 
+* Updated `cuminc()` and `crr()` to drop un-observed factor levels before processing the data. Previously, un-observed levels led to a singularity error. (#76)
+
 * Re-wrote an `ifelse()` statement to avoid a warning when tied times are present in `cuminc()`. (#74)
 
 # tidycmprsk 0.1.2

--- a/R/crr.R
+++ b/R/crr.R
@@ -23,6 +23,7 @@ NULL
 #' @rdname crr
 #' @export
 crr.formula <- function(formula, data, failcode = NULL, conf.level = 0.95, ...) {
+  if (!missing(data)) data <- droplevels(data)
 
   # checking inputs and assigning the numeric failcode -------------------------
   failcode_numeric <-
@@ -43,6 +44,7 @@ crr_mold <- function(formula, data) {
     )
   # remove intercept
   processed$predictors <- processed$predictors[, -1]
+
   processed
 }
 

--- a/R/crr.R
+++ b/R/crr.R
@@ -23,8 +23,6 @@ NULL
 #' @rdname crr
 #' @export
 crr.formula <- function(formula, data, failcode = NULL, conf.level = 0.95, ...) {
-  if (!missing(data)) data <- droplevels(data)
-
   # checking inputs and assigning the numeric failcode -------------------------
   failcode_numeric <-
     as_numeric_failcode(formula = formula, data = data, failcode = failcode)
@@ -45,6 +43,16 @@ crr_mold <- function(formula, data) {
   # remove intercept
   processed$predictors <- processed$predictors[, -1]
 
+  # removing unobserved levels (converted to all zero for dummy variable)
+  processed$predictors <-
+    processed$predictors %>%
+    purrr::map_dfc(
+      function(.x) {
+        if (all(.x == 0)) return(NULL)
+        .x
+      }
+    )
+
   processed
 }
 
@@ -58,7 +66,7 @@ as_numeric_failcode <- function(formula, data, failcode, keep_all = FALSE) {
       },
       error = function(e) {
         cli::cli_alert_danger("There was an error evaluating the LHS of the formula.")
-        stop(e, call. = FALSE)
+        stop(as.character(e), call. = FALSE)
       }
     )
 

--- a/R/cuminc.R
+++ b/R/cuminc.R
@@ -36,6 +36,7 @@ NULL
 #' @rdname cuminc
 #' @export
 cuminc.formula <- function(formula, data, strata, rho = 0, conf.level = 0.95, ...) {
+  if (!missing(data)) data <- droplevels(data)
 
   # extracting failure level ---------------------------------------------------
   failcode_numeric <-

--- a/R/tbl_cuminc.R
+++ b/R/tbl_cuminc.R
@@ -1,7 +1,5 @@
 #' Tabular Summary of Cumulative Incidence
 #'
-#' *This is experimental and breaking changes may be made in a future release.*
-#'
 #' @param x a 'tidycuminc' object created with `cuminc()`
 #' @param outcomes character vector of outcomes to include. Default
 #' is to include the first outcome.
@@ -227,7 +225,6 @@ tbl_cuminc <- function(x, ...) {
 #' Additional Functions for `tbl_cuminc()`
 #'
 #' @description
-#' *This is experimental and breaking changes may be made in a future release.*
 #'
 #' - `add_p()` Add column with p-value comparing incidence across stratum
 #' - `add_n()` Add column with the total N, or N within stratum

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ crr_mod <- crr(Surv(ttdeath, death_cr) ~ age + trt, trial)
 #> 11 cases omitted due to missing values
 crr_mod
 #> 
-#> -- crr() -----------------------------------------------------------------------
-#> * Call Surv(ttdeath, death_cr) ~ age + trt
-#> * Failure type of interest "death from cancer"
+#> ── crr() ───────────────────────────────────────────────────────────────────────
+#> • Call Surv(ttdeath, death_cr) ~ age + trt
+#> • Failure type of interest "death from cancer"
 #> 
 #> Variable    Coef    SE      HR     95% CI       p-value    
 #> age         0.006   0.010   1.01   0.99, 1.03   0.56       
@@ -62,6 +62,7 @@ The `tidycmprsk` plays well with other packages, such as `gtsummary`.
 tbl <- 
   crr_mod %>%
   gtsummary::tbl_regression(exponentiate = TRUE) %>%
+  gtsummary::add_global_p() %>%
   add_n(location = "level")
 ```
 
@@ -77,14 +78,14 @@ gtsummary::inline_text(tbl, variable = age)
 ``` r
 cuminc(Surv(ttdeath, death_cr) ~ 1, trial)
 #> 
-#> -- cuminc() --------------------------------------------------------------------
-#> * Failure type "death from cancer"
+#> ── cuminc() ────────────────────────────────────────────────────────────────────
+#> • Failure type "death from cancer"
 #> time   n.risk   estimate   std.error   95% CI          
 #> 5.00   199      0.000      0.000       NA, NA          
 #> 10.0   189      0.030      0.012       0.012, 0.061    
 #> 15.0   158      0.120      0.023       0.079, 0.169    
 #> 20.0   116      0.215      0.029       0.161, 0.274
-#> * Failure type "death other causes"
+#> • Failure type "death other causes"
 #> time   n.risk   estimate   std.error   95% CI          
 #> 5.00   199      0.005      0.005       0.000, 0.026    
 #> 10.0   189      0.025      0.011       0.009, 0.054    
@@ -121,7 +122,9 @@ Conduct](https://mskcc-epi-bio.github.io/tidycmprsk/CODE_OF_CONDUCT.html).
 By contributing to this project, you agree to abide by its terms. Thank
 you to all contributors!  
 [@ddsjoberg](https://github.com/ddsjoberg),
-[@karissawhiting](https://github.com/karissawhiting), and
+[@erikvona](https://github.com/erikvona),
+[@karissawhiting](https://github.com/karissawhiting),
+[@m-freitag](https://github.com/m-freitag), and
 [@tengfei-emory](https://github.com/tengfei-emory)
 
 #### Limitations

--- a/tests/testthat/test-crr.R
+++ b/tests/testthat/test-crr.R
@@ -13,6 +13,15 @@ test_that("crr() works", {
   )
 
   expect_equal(
+    crr(Surv(ttdeath, death_cr) ~ age + trt,
+        data = trial %>% dplyr::mutate(trt = factor(trt, levels = paste("Drug", c("A", "B", "C"))))) %>%
+      utils::modifyList(val = list(data = NULL, blueprint = NULL, xlevels = NULL)),
+    crr(Surv(ttdeath, death_cr) ~ age + trt,
+        data = trial %>% dplyr::mutate(trt = factor(trt))) %>%
+      utils::modifyList(val = list(data = NULL, blueprint = NULL, xlevels = NULL))
+  )
+
+  expect_equal(
     tidy(crr1, conf.int = TRUE) %>%
       select(all_of(names(.) %>% sort())),
     broom::tidy(crr1$cmprsk, conf.int = TRUE, conf.level = 0.90) %>%


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Updated `cuminc()` and `crr()` to drop un-observed factor levels before processing the data. Previously, un-observed levels led to a singularity error.

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #76 
closes #59

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# tidycmprsk (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end of the update.
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

