### PR TITLE
bug fix for stratum with no observed outcome(s)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidycmprsk
 Title: Competing Risks Estimation
-Version: 0.1.2.9004
+Version: 0.1.2.9005
 Authors@R: c(
     person(c("Daniel", "D."), "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018")),
@@ -18,12 +18,12 @@ BugReports: https://github.com/MSKCC-Epi-Bio/tidycmprsk/issues/
 Depends: 
     R (>= 3.4)
 Imports: 
-    broom (>= 0.7.11),
+    broom (>= 1.0.1),
     cli (>= 3.1.0),
     cmprsk (>= 2.2.10),
     dplyr (>= 1.0.7),
     ggplot2 (>= 3.3.5),
-    gtsummary (>= 1.6.1),
+    gtsummary (>= 1.6.1.9000),
     hardhat (>= 0.2.0),
     purrr (>= 0.3.4),
     rlang (>= 1.0.0),
@@ -39,7 +39,8 @@ Suggests:
     testthat (>= 3.1.0)
 Remotes:
     r-lib/tidyselect,
-    tidyverse/tidyr
+    tidyverse/tidyr,
+    ddsjoberg/gtsummary
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidycmprsk (development version)
 
+* Fix in `cuminc()` when one or more strata levels has no observations with one of the outcomes observed.
+
 * The `autoplot.tidycuminc()` method has been deprecated in favor of `ggsurvfit::ggcuminc()`. (#81)
 
 * Updated `cuminc()` and `crr()` to drop un-observed factor levels before processing the data. Previously, un-observed levels led to a singularity error. (#76)

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -316,6 +316,11 @@ add_n_stats <- function(df_tidy, x) {
     filter(.data$status != 0) %>%
     select(-dplyr::all_of("status")) %>%
     dplyr::distinct() %>%
+    dplyr::ungroup() %>%
+    # all of this below is just in case a particular stratum does not have any observed events of any of the outcomes
+    tidyr::complete(., !!!rlang::syms(intersect(c("strata", "outcome"), names(.)))) %>%
+    group_by(across(any_of(c("strata")))) %>%
+    tidyr::fill(dplyr::all_of(c("time", "n.event", "n.risk", "n.censor")), .direction = "updown") %>%
     dplyr::ungroup()
 
   df_Surv <-

--- a/tests/testthat/test-cuminc.R
+++ b/tests/testthat/test-cuminc.R
@@ -87,5 +87,26 @@ test_that("cuminc() works", {
     cuminc(Surv(drat, factor(cyl)) ~ 1, mtcars),
     NA
   )
+
+  # check when one stratum has no observed values of a particular outcome
+  expect_equal(
+    cuminc(
+      Surv(ttdeath, death_cr) ~ grade,
+      # remove all other cause death obs for grade "I"
+      data = trial %>% dplyr::filter(!(grade == "I" & death_cr == "death other causes"))
+    ) %>%
+      purrr::pluck("tidy") %>%
+      dplyr::filter(time == 0),
+    tibble::tribble(
+      ~time,         ~outcome, ~strata, ~estimate, ~std.error,       ~conf.low,       ~conf.high, ~n.risk, ~n.event, ~n.censor, ~cum.event, ~cum.censor,
+      0,  "death from cancer",     "I",         0,          0,        NA_real_,         NA_real_,     53L,       0L,        0L,         0L,          0L,
+      0, "death other causes",     "I",         0,          0,        NA_real_,         NA_real_,     53L,       0L,        0L,         0L,          0L,
+      0,  "death from cancer",    "II",         0,          0,        NA_real_,         NA_real_,     68L,       0L,        0L,         0L,          0L,
+      0, "death other causes",    "II",         0,          0,        NA_real_,         NA_real_,     68L,       0L,        0L,         0L,          0L,
+      0,  "death from cancer",   "III",         0,          0,        NA_real_,         NA_real_,     64L,       0L,        0L,         0L,          0L,
+      0, "death other causes",   "III",         0,          0,        NA_real_,         NA_real_,     64L,       0L,        0L,         0L,          0L
+    ) %>%
+      dplyr::mutate(strata = factor(strata, levels = c("I", "II", "III")))
+  )
 })
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix in `cuminc()` when one or more strata levels has no observations with one of the outcomes observed.


--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from master branch. Ensure the pull request branch and your local version match and both have the latest updates from the master branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, set `Sys.setenv(NOT_CRAN="true")` and begin in a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# tidycmprsk (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end of the update.
- [ ] Increment the version number using `usethis::use_version(which = "dev")` 
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".

